### PR TITLE
Fix for Cannot read Memo type from Foxpro, issue number 30

### DIFF
--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -195,9 +195,13 @@ class Record
 
     public function getMemo($columnName)
     {
-        $data = $this->forceGetString($columnName);
+        $data = trim($this->choppedData[$columnName]);
         if($data && strlen($data) == 2) {
             $pointer = unpack('s', $data)[1];
+            return $this->memoFile->get($pointer);
+	}
+	elseif($data && strlen($data) == 4) {
+            $pointer = unpack('l', $data)[1];
             return $this->memoFile->get($pointer);
         } else {
             return $data;


### PR DESCRIPTION
Updated the getMemo function with:
1. Don't convert the pointer to UTF-8, it's not text ...
2. Handle 4 byte (long integer) pointers into memo files.