### PR TITLE
fixing php7.3 deprecation error for strpos in the Column file

### DIFF
--- a/src/XBase/Column.php
+++ b/src/XBase/Column.php
@@ -21,7 +21,7 @@ class Column
     public function __construct($name, $type, $memAddress, $length, $decimalCount, $reserved1, $workAreaID, $reserved2, $setFields, $reserved3, $indexed, $colIndex, $bytePos) 
     {
         $this->rawname = $name;
-        $this->name = (strpos($name, 0x00) !== false ) ? substr($name, 0, strpos($name, 0x00)) : $name;
+        $this->name = (strpos($name, chr(0x00)) !== false ) ? substr($name, 0, strpos($name, chr(0x00))) : $name;
         $this->type = $type;
         $this->memAddress = $memAddress;
         $this->length = $length;


### PR DESCRIPTION
> needle
> If needle is not a string, it is converted to an integer and applied as the ordinal value of a character. This behavior is deprecated as of PHP 7.3.0, and relying on it is highly discouraged. Depending on the intended behavior, the needle should either be explicitly cast to string, or an explicit call to chr() should be performed.

http://php.net/manual/en/function.strpos.php