### PR TITLE
Исправил баг смены кодировки

### DIFF
--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -113,7 +113,7 @@ class Record
         $data = trim($this->choppedData[$columnName]);
 
         if ($this->table->getConvertFrom()) {
-            $data = iconv($this->table->getConvertFrom(), 'utf-8', $data);
+            $data = iconv($this->table->getConvertFrom(), 'utf-8', convert_cyr_string($data, 'd', 'w'));
         }
 
         if (!isset($data[0]) || ord($data[0]) === 0) {


### PR DESCRIPTION
У меня была большая проблема с кодировкой. Тот DBF файл, что я использовал содержал кириллические символы, а  указание кодировки `windows-1251` превращало их в абракадабру. Оборачивание в `convert_cyr_string( ... )` помогло).