### PR TITLE
VisualFoxPro Memo: change unpack type from signed short to signed long

### DIFF
--- a/example/test-memo.php
+++ b/example/test-memo.php
@@ -1,0 +1,34 @@
+<?php
+// php test-memo.php ../tests/Resources/foxpro/1.dbf memo_field_name
+
+use XBase\Table;
+
+require_once '../vendor/autoload.php';
+
+/**
+ * CLI usage: php test-memo.php [path to a dbf file] [memo_field_name]
+ **/
+
+if (empty($argv[1])) {
+    die('database file argument not defined?');
+}
+if (empty($argv[2])) {
+    die('memo field name not defined?');
+}
+$filepath = realpath($argv[1]);
+if (false === $filepath || !is_file($filepath)) {
+    die('Bad path to file realpath '.$argv[1]);
+}
+
+$table = new Table($filepath, null, 'cp1252');
+echo 'Record count: '.$table->getRecordCount() . PHP_EOL;
+
+$columns = $table->getColumns();
+
+//print_r($columns);exit;
+
+$i = 0;
+while ($record = $table->nextRecord()) {
+    $memo = $record->{$argv[2]};
+    echo $memo . PHP_EOL;
+}

--- a/src/XBase/Memo/VisualFoxproMemo.php
+++ b/src/XBase/Memo/VisualFoxproMemo.php
@@ -9,7 +9,7 @@ class VisualFoxproMemo extends FoxproMemo
      */
     public function get($pointer)
     {
-        $decPointer = unpack('s', $pointer)[1];
+        $decPointer = unpack('l', $pointer)[1];
         return parent::get($decPointer);
     }
 }


### PR DESCRIPTION
For bigger files short type runs out of range and causes errors reading memo. 