### PR TITLE
Include high-order byte in field length calculation for non-numeric fields

### DIFF
--- a/src/XBase/Column/DBaseColumn.php
+++ b/src/XBase/Column/DBaseColumn.php
@@ -46,7 +46,7 @@ class DBaseColumn extends AbstractColumn
         $this->name = strtolower($name);
         $this->type = $type;
         $this->memAddress = $memAddress;
-        $this->length = $length;
+        $this->length = in_array($this->type, ['M','C']) ? $length + 256*$decimalCount : $length;
         $this->decimalCount = $decimalCount;
         $this->workAreaID = $workAreaID;
         $this->setFields = $setFields;


### PR DESCRIPTION
This is what I have to do to get correct memo field lengths on a bunch of DBF files that I have to read in. Throwing it out there for consideration.

See #7 at http://www.manmrk.net/tutorials/database/xbase/dbf.html#DBF_NOTE_7_SOURCE