### PR TITLE
Add support for DBase 7 Double type

### DIFF
--- a/src/XBase/DataConverter/Field/DBase7/DoubleConverter.php
+++ b/src/XBase/DataConverter/Field/DBase7/DoubleConverter.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace XBase\DataConverter\Field\DBase7;
+
+use XBase\DataConverter\Field\AbstractFieldDataConverter;
+use XBase\Enum\FieldType;
+
+class DoubleConverter extends AbstractFieldDataConverter
+{
+    public static function getType(): string
+    {
+        return FieldType::DBASE7_DOUBLE;
+    }
+
+    public function fromBinaryString(string $value): float
+    {
+        $buf = unpack('C*', $value);
+        $buf = array_map(function ($v) {
+            return str_pad(decbin($v), 8, '0', STR_PAD_LEFT);
+        }, $buf);
+        
+        $negative = '0' === $buf[1][0];
+        if ($negative) {
+            $buf = array_map(function ($v) {
+                return $this->inverseBits($v);
+            }, $buf);
+        }
+        
+        $result = unpack('E', pack('C*', ...array_map('bindec', $buf)));
+        if ($result) {
+            $result = (float) abs($result[1]);
+            if ($negative) {
+                $result = -($result);
+            }
+            
+            return $result;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * @param float|null $value
+     */
+    public function toBinaryString($value): string
+    {
+        if (null === $value) {
+            return str_pad('', $this->column->getLength(), chr(0x00));
+        }
+
+        return pack('E', $value);
+    }
+    
+    private function inverseBits(string $bin): string
+    {
+       $len = strlen($bin);
+       $result = '';
+       for ($i = 0; $i < $len; $i++) {
+           $result .= '0' === $bin[$i] ? '1' : '0';
+       }
+    
+       return $result;
+    }
+}

--- a/src/XBase/DataConverter/Record/DBase7DataConverter.php
+++ b/src/XBase/DataConverter/Record/DBase7DataConverter.php
@@ -3,6 +3,7 @@
 namespace XBase\DataConverter\Record;
 
 use XBase\DataConverter\Field\DBase7\AiConverter;
+use XBase\DataConverter\Field\DBase7\DoubleConverter;
 use XBase\DataConverter\Field\DBase7\IntegerConverter;
 use XBase\DataConverter\Field\DBase7\MemoConverter;
 use XBase\DataConverter\Field\DBase7\TimestampConverter;
@@ -13,6 +14,7 @@ class DBase7DataConverter extends DBase4DataConverter
     {
         return array_merge([
             AiConverter::class,
+            DoubleConverter::class,
             IntegerConverter::class,
             TimestampConverter::class,
             MemoConverter::class,

--- a/src/XBase/Enum/FieldType.php
+++ b/src/XBase/Enum/FieldType.php
@@ -36,6 +36,7 @@ final class FieldType
     const AUTO_INCREMENT = '+';
 
     const DBASE4_BLOB = 'B';
+    const DBASE7_DOUBLE = 'O';
 
     public static function has($type): bool
     {

--- a/tests/DataConverter/Field/DBase7/DoubleConverterTest.php
+++ b/tests/DataConverter/Field/DBase7/DoubleConverterTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace XBase\Tests\Record\DataConverter\Field\DBase7;
+
+use PHPUnit\Framework\TestCase;
+use XBase\Column\ColumnInterface;
+use XBase\DataConverter\Field\DBase7\DoubleConverter;
+use XBase\Table;
+
+class DoubleConverterTest extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function test(string $binaryString, float $float): void
+    {
+        $table = $this->createMock(Table::class);
+        $column = $this->createMock(ColumnInterface::class);
+        $converter = new DoubleConverter($table, $column);
+        self::assertSame($float, $converter->fromBinaryString($binaryString));
+        self::assertEquals($float, unpack('E', $converter->toBinaryString($float))[1]);
+    }
+
+    public function dataProvider()
+    {
+        yield [
+            base64_decode('P5cDMzMzMzI='),
+            -199.9,
+        ];
+
+        yield [
+            base64_decode('P61f//////8='),
+            -74.5,
+        ];
+
+        yield [
+            base64_decode('gAAAAAAAAAA='),
+            0.0,
+        ];
+        
+        yield [
+            base64_decode('wCIAAAAAAAA='),
+            9.0
+        ];
+
+        yield [
+            base64_decode('wFOMzMzMzM0='),
+            78.2,
+        ];
+    }
+}


### PR DESCRIPTION
This adds support for the DBase 7 Double type (O) as documented [here](http://www.dbase.com/KnowledgeBase/int/db7_file_fmt.htm).

These are handled similarly to DB7 integers, and so the converter class is built similarly to that.