### PR TITLE
Create encoder: MbConvertEncodingEncoder

### DIFF
--- a/src/DataConverter/Encoder/MbConvertEncodingEncoder.php
+++ b/src/DataConverter/Encoder/MbConvertEncodingEncoder.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace XBase\DataConverter\Encoder;
+
+class MbConvertEncodingEncoder implements EncoderInterface
+{
+    public function encode(string $string, string $fromEncoding, string $toEncoding): string
+    {
+        return mb_convert_encoding($string, $toEncoding, $fromEncoding);
+    }
+}


### PR DESCRIPTION
Hi,
In `TableReader`, `IconvEncoder` is used by default.
When `iconv("BIG5", "UTF-8", $string)` fails, the program will interrupt immediately and return an error.
However, by using `mb_convert_encoding()`, the program can still run normally even though some BIG5 strings fail to be converted into UTF-8.

To prevent errors when converting, I created the `MbConvertEncodingEncoder` as another encoding option, to use `mb_convert_encoding()` to convert strings.