### PR TITLE
add AllowDynamicProperties for XBase\Header\Column::* properties to fix deprecation warnings

### DIFF
--- a/src/Header/Column.php
+++ b/src/Header/Column.php
@@ -14,6 +14,7 @@ namespace XBase\Header;
  * @property int $mdxFlag
  * @property int $nextAI
  */
+#[\AllowDynamicProperties]
 class Column
 {
     /** @var string */


### PR DESCRIPTION
Fix PHP 8.2 deprecations related to dynamic properties:

```
Deprecated: Creation of dynamic property XBase\Header\Column::$reserved1 is deprecated in ... on line 37
Deprecated: Creation of dynamic property XBase\Header\Column::$reserved2 is deprecated in ... on line 37
Deprecated: Creation of dynamic property XBase\Header\Column::$reserved3 is deprecated in ... on line 37
Deprecated: Creation of dynamic property XBase\Header\Column::$columnIndex is deprecated in ... on line 75
```