### PR TITLE
Fix memory exhaustion when reading corrupted FPT memo files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=clover.xml
 
       - name: Upload coverage file artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.php-version }}-${{ matrix.dependencies }}
           path: clover.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Codeclimate binary
         run: |
-          curl -L https://github.com/codeclimate/test-reporter/releases/latest/download/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          curl -L -f https://codeclimate.com/downloads/test-reporter/test-reporter-0.11.1-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
 
       - name: Run Codeclimate before-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install Codeclimate binary
         run: |
-          curl -L https://github.com/codeclimate/test-reporter/releases/latest/download/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          curl -L -f https://codeclimate.com/downloads/test-reporter/test-reporter-0.11.1-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
 
       - name: Upload to Codeclimate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,53 +44,22 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      - name: Install Codeclimate binary
-        run: |
-          curl -L -f https://codeclimate.com/downloads/test-reporter/test-reporter-0.11.1-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-
-      - name: Run Codeclimate before-build
-        run: ./cc-test-reporter before-build
-
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover=clover.xml
 
-      - name: Upload clover artifact
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # Token nájdeš v nastaveniach Codecov.io
+          files: ./clover.xml
+          flags: php-${{ matrix.php-version }}
+          fail_ci_if_error: true
+
+      - name: Upload clover artifact for Coveralls
         uses: actions/upload-artifact@v4
         with:
           name: clover-${{ matrix.php-version }}-${{ matrix.dependencies }}
           path: clover.xml
-
-      - name: Run Codeclimate format-coverage
-        run: ./cc-test-reporter format-coverage -o codeclimate.json -t clover clover.xml
-
-      - name: Upload codeclimate artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cc-${{ matrix.php-version }}-${{ matrix.dependencies }}
-          path: codeclimate.json
-
-  codeclimate-upload:
-    name: Upload coverage to Codeclimate
-    runs-on: ubuntu-latest
-    needs: phpunit
-    env:
-      CC_TEST_REPORTER_ID: e33b74ed1f59947df361652193b6575db0afc663dcbc73af89a0cf16f2443d24
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: coverage
-
-      - name: Install Codeclimate binary
-        run: |
-          curl -L -f https://codeclimate.com/downloads/test-reporter/test-reporter-0.11.1-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-
-      - name: Upload to Codeclimate
-        run: |
-          ./cc-test-reporter sum-coverage coverage/cc-*/codeclimate.json -p 6
-          ./cc-test-reporter upload-coverage
 
   coveralls-upload:
     name: Upload coverage to Coveralls
@@ -114,7 +83,4 @@ jobs:
       - name: Install php-coveralls
         run: composer global require php-coveralls/php-coveralls
 
-      - name: Upload coverage results to Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: php-coveralls --coverage_clover="build/logs/clover-*/clover.xml" -v
+      -

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,39 +10,27 @@ jobs:
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: php-actions/composer@v5
-
+      - uses: actions/checkout@v4
+      - uses: php-actions/composer@v6
       - name: PHPStan
         uses: chindit/actions-phpstan@master
         with:
-          # Arguments to add to PHPStan
           arguments: 'src/'
 
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        php-version:
-          - 7.1
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
-        dependencies:
-          - highest
+        php-version: [7.1, 7.2, 7.3, 7.4, 8.0]
+        dependencies: [highest]
         include:
           - php-version: 7.1
             dependencies: lowest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -52,65 +40,64 @@ jobs:
           ini-values: zend.assertions=1
 
       - name: Install dependencies with Composer
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      - name: Install Codeclimate binary
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
-          chmod +x ./cc-test-reporter
+      # Oprava sťahovania Code Climate binárky cez oficiálnu akciu
+      - name: Setup Code Climate test-reporter
+        uses: amancevice/setup-codeclimate@v0
+        with:
+          version: latest
 
       - name: Run Codeclimate before-build
-        run: ./cc-test-reporter before-build
+        run: cc-test-reporter before-build
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover=clover.xml
 
-      - name: Upload coverage file artifact
+      - name: Upload clover artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.php-version }}-${{ matrix.dependencies }}
+          name: clover-${{ matrix.php-version }}-${{ matrix.dependencies }}
           path: clover.xml
 
       - name: Run Codeclimate format-coverage
-        run: ./cc-test-reporter format-coverage -o codeclimate.json
+        run: cc-test-reporter format-coverage -o codeclimate.json -t clover clover.xml
 
-      - name: Upload coverage file artifact
+      - name: Upload codeclimate artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.php-version }}-${{ matrix.dependencies }}
+          name: cc-${{ matrix.php-version }}-${{ matrix.dependencies }}
           path: codeclimate.json
-
 
   codeclimate-upload:
     name: Upload coverage to Codeclimate
     runs-on: ubuntu-latest
-    needs:
-      - phpunit
+    needs: phpunit
     env:
       CC_TEST_REPORTER_ID: e33b74ed1f59947df361652193b6575db0afc663dcbc73af89a0cf16f2443d24
     steps:
-      - name: Download coverage files
-        uses: actions/download-artifact@v2
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
           path: coverage
-      - name: Install Codeclimate binary
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
-          chmod +x ./cc-test-reporter
-      - run: ./cc-test-reporter sum-coverage coverage/*/codeclimate.json
-      - run: ./cc-test-reporter upload-coverage
 
+      - name: Setup Code Climate test-reporter
+        uses: amancevice/setup-codeclimate@v0
+
+      - name: Upload to Codeclimate
+        run: |
+          cc-test-reporter sum-coverage coverage/cc-*/codeclimate.json -p ${{ strategy.job-total || 6 }}
+          cc-test-reporter upload-coverage
 
   coveralls-upload:
     name: Upload coverage to Coveralls
     runs-on: ubuntu-latest
-    needs:
-      - phpunit
+    needs: phpunit
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -118,8 +105,8 @@ jobs:
           php-version: 7.4
           coverage: none
 
-      - name: Download coverage files
-        uses: actions/download-artifact@v2
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
           path: build/logs
 
@@ -129,4 +116,4 @@ jobs:
       - name: Upload coverage results to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: php-coveralls --coverage_clover=build/logs/*/clover.xml -v
+        run: php-coveralls --coverage_clover="build/logs/clover-*/clover.xml" -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - '*'
 
 jobs:
   phpstan:
@@ -50,12 +51,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # Token nájdeš v nastaveniach Codecov.io
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./clover.xml
-          flags: php-${{ matrix.php-version }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
-      - name: Upload clover artifact for Coveralls
+      - name: Upload clover artifact
         uses: actions/upload-artifact@v4
         with:
           name: clover-${{ matrix.php-version }}-${{ matrix.dependencies }}
@@ -83,4 +83,7 @@ jobs:
       - name: Install php-coveralls
         run: composer global require php-coveralls/php-coveralls
 
-      -
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: php-coveralls --coverage_clover="build/logs/clover-*/clover.xml" -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,14 +44,13 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      # Oprava sťahovania Code Climate binárky cez oficiálnu akciu
-      - name: Setup Code Climate test-reporter
-        uses: amancevice/setup-codeclimate@v0
-        with:
-          version: latest
+      - name: Install Codeclimate binary
+        run: |
+          curl -L https://github.com/codeclimate/test-reporter/releases/latest/download/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
 
       - name: Run Codeclimate before-build
-        run: cc-test-reporter before-build
+        run: ./cc-test-reporter before-build
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover=clover.xml
@@ -63,7 +62,7 @@ jobs:
           path: clover.xml
 
       - name: Run Codeclimate format-coverage
-        run: cc-test-reporter format-coverage -o codeclimate.json -t clover clover.xml
+        run: ./cc-test-reporter format-coverage -o codeclimate.json -t clover clover.xml
 
       - name: Upload codeclimate artifact
         uses: actions/upload-artifact@v4
@@ -83,13 +82,15 @@ jobs:
         with:
           path: coverage
 
-      - name: Setup Code Climate test-reporter
-        uses: amancevice/setup-codeclimate@v0
+      - name: Install Codeclimate binary
+        run: |
+          curl -L https://github.com/codeclimate/test-reporter/releases/latest/download/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
 
       - name: Upload to Codeclimate
         run: |
-          cc-test-reporter sum-coverage coverage/cc-*/codeclimate.json -p ${{ strategy.job-total || 6 }}
-          cc-test-reporter upload-coverage
+          ./cc-test-reporter sum-coverage coverage/cc-*/codeclimate.json -p 6
+          ./cc-test-reporter upload-coverage
 
   coveralls-upload:
     name: Upload coverage to Coveralls

--- a/src/Memo/FoxproMemo.php
+++ b/src/Memo/FoxproMemo.php
@@ -51,6 +51,12 @@ class FoxproMemo extends AbstractWritableMemo
         $info = unpack('N', $this->fp->read(self::BLOCK_TYPE_LENGTH)); //todo figure out type-enums
 
         $memoLength = unpack('N', $this->fp->read(self::BLOCK_LENGTH_LENGTH));
+        
+        // Safety check: prevent reading corrupted/huge memo fields (max 100MB)
+        if ($memoLength[1] > 104857600) {
+            throw new \Exception("Corrupted FPT file: memo field size {$memoLength[1]} bytes exceeds 100MB limit");
+        }
+        
         $result = $this->fp->read($memoLength[1]);
 
         $info = $this->guessDataType($result);


### PR DESCRIPTION
Prevents the memo reader from attempting to allocate excessive memory when encountering corrupted FPT files. 

Added a safety check to limit the maximum memo length to 100MB per column, preventing fatal memory errors (e.g., attempts to allocate ~1.9GB) during file processing.